### PR TITLE
Add calculations for umax and vmax

### DIFF
--- a/io/post_fv3.F90
+++ b/io/post_fv3.F90
@@ -430,7 +430,9 @@ module post_fv3
             if (trim(attName) == 'ncnsto') wrt_int_state%ntrac=varival
             if (trim(attName) == 'ncld')   wrt_int_state%ncld=varival
             if (trim(attName) == 'nsoil')  wrt_int_state%nsoil=varival
+            if (trim(attName) == 'fhzero')  wrt_int_state%fhzero=varival
             if (trim(attName) == 'imp_physics') wrt_int_state%imp_physics=varival
+            if (trim(attName) == 'landsfcmdl') wrt_int_state%landsfcmdl=varival
           endif
         else if (typekind==ESMF_TYPEKIND_R4) then
           if(n==1) then
@@ -554,7 +556,7 @@ module post_fv3
                              no3cb, nh4cb, dusmass, ducmass, dusmass25,ducmass25, &
                              snownc, graupelnc, qrmax, hail_maxhailcast,       &
                              smoke_ave,dust_ave,coarsepm_ave,swddif,swddni,    &
-                             xlaixy
+                             xlaixy,wspd10umax,wspd10vmax
       use soil,        only: sldpth, sh2o, smc, stc, sllevel
       use masks,       only: lmv, lmh, htm, vtm, gdlat, gdlon, dx, dy, hbm2, sm, sice
       use ctlblk_mod,  only: im, jm, lm, lp1, jsta, jend, jsta_2l, jend_2u, jsta_m,jend_m, &
@@ -1367,13 +1369,48 @@ module post_fv3
               enddo
             endif
 
-            ! max hourly 10m agl wind speed
-            if(trim(fieldname)=='spd10max') then
+            ! max temporal 10m agl wind speed
+            if (modelname =='GFS')then
+            if(trim(fieldname)=='wind10m_max') then
               !$omp parallel do default(none) private(i,j) shared(jsta,jend,ista,iend,spval,wspd10max,arrayr42d,sm,fillValue)
               do j=jsta,jend
                 do i=ista, iend
                   wspd10max(i,j) = arrayr42d(i,j)
                   if (abs(arrayr42d(i,j)-fillValue) < small) wspd10max(i,j) = spval
+                enddo
+              enddo
+            endif
+            else
+            ! max hourly 10m agl wind speed
+            if(trim(fieldname)=='spd10max') then
+              !$omp parallel do default(none) private(i,j) shared(jsta,jend,ista,iend,spval,wspd10max,arrayr42d,sm,fillValue)
+              do j=jsta,jend 
+                do i=ista, iend
+                  wspd10max(i,j) = arrayr42d(i,j)
+                  if (abs(arrayr42d(i,j)-fillValue) < small) wspd10max(i,j) = spval
+                enddo        
+              enddo          
+            endif  
+            endif !end modelname
+
+            ! u comp of temporal max 10m agl wind speed 
+            if(trim(fieldname)=='u10m_max') then
+              !$omp parallel do default(none) private(i,j) shared(jsta,jend,ista,iend,spval,wspd10umax,arrayr42d,sm,fillValue)
+              do j=jsta,jend
+                do i=ista, iend
+                  wspd10umax(i,j) = arrayr42d(i,j)
+                  if (abs(arrayr42d(i,j)-fillValue) < small) wspd10umax(i,j) = spval
+                enddo
+              enddo
+            endif
+
+            ! v comp of temporal max 10m agl wind speed 
+            if(trim(fieldname)=='v10m_max') then
+              !$omp parallel do default(none) private(i,j) shared(jsta,jend,ista,iend,spval,wspd10vmax,arrayr42d,sm,fillValue)
+              do j=jsta,jend
+                do i=ista, iend
+                  wspd10vmax(i,j) = arrayr42d(i,j)
+                  if (abs(arrayr42d(i,j)-fillValue) < small) wspd10vmax(i,j) = spval
                 enddo
               enddo
             endif


### PR DESCRIPTION
This PR adds the calculations necessary (from FV3 PR [880](https://github.com/NOAA-EMC/fv3atm/pull/880)) to get 10-m max u and v wind as requested by CPC. The goal is to add these specific changes to an FV3 branch (namely `feature/gefs_reforecast`) with the ee3378b9d56d5d4fa1b9e1cd16b06760ad810601 hash (August 23rd, 2024). This is the FV3 hash the GEFSv13 reforecast will use.
